### PR TITLE
update for tiny frontend 0.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiny-frontend/tiny-client-react",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,14 +6,14 @@
   "packages": {
     "": {
       "name": "@tiny-frontend/tiny-client-react",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "devDependencies": {
         "@cazoo/eslint-plugin-eslint": "^1.0.2",
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.3",
         "@testing-library/react-hooks": "^7.0.2",
-        "@tiny-frontend/client": "^0.0.3",
+        "@tiny-frontend/client": "^0.0.7",
         "@types/jest": "^27.4.1",
         "@types/react": "^16.8.0",
         "@types/react-dom": "^16.8.0",
@@ -1226,9 +1226,9 @@
       }
     },
     "node_modules/@tiny-frontend/client": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@tiny-frontend/client/-/client-0.0.3.tgz",
-      "integrity": "sha512-8sMzFx2A4D0UOcJr9+znzte5/I2rV0UZOra3SEJ6bDVT+Ws8Z7CPf7TD6hkMsXzIGdGOTqswquJ7g/9MF57Xww==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@tiny-frontend/client/-/client-0.0.7.tgz",
+      "integrity": "sha512-wg5mtImX1KXj9UospPYe9ExjcW9j2jt+kKjDP5/RAdvxFfUMnrs6YzsedZfgke0x08s1Cdnup2yjV2mm2YiJzQ==",
       "dev": true,
       "dependencies": {
         "@ungap/global-this": "^0.4.4"
@@ -8291,9 +8291,9 @@
       }
     },
     "@tiny-frontend/client": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@tiny-frontend/client/-/client-0.0.3.tgz",
-      "integrity": "sha512-8sMzFx2A4D0UOcJr9+znzte5/I2rV0UZOra3SEJ6bDVT+Ws8Z7CPf7TD6hkMsXzIGdGOTqswquJ7g/9MF57Xww==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@tiny-frontend/client/-/client-0.0.7.tgz",
+      "integrity": "sha512-wg5mtImX1KXj9UospPYe9ExjcW9j2jt+kKjDP5/RAdvxFfUMnrs6YzsedZfgke0x08s1Cdnup2yjV2mm2YiJzQ==",
       "dev": true,
       "requires": {
         "@ungap/global-this": "^0.4.4"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.3",
     "@testing-library/react-hooks": "^7.0.2",
-    "@tiny-frontend/client": "^0.0.3",
+    "@tiny-frontend/client": "^0.0.7",
     "@types/jest": "^27.4.1",
     "@types/react": "^16.8.0",
     "@types/react-dom": "^16.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiny-frontend/tiny-client-react",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "license": "MIT",
   "scripts": {
     "dev": "vite",

--- a/src/TinyHead.test.tsx
+++ b/src/TinyHead.test.tsx
@@ -46,7 +46,7 @@ describe("[TinyHead]", () => {
       const expected = "http://other-js-url.js/";
       const { container } = renderTinyHead({ jsBundle: expected });
 
-      const link = container.querySelector("link[as=fetch]") as HTMLLinkElement;
+      const link = container.querySelector("link[as=script]") as HTMLLinkElement;
       const result = link.href;
 
       expect(result).toBe(expected);

--- a/src/TinyHead.tsx
+++ b/src/TinyHead.tsx
@@ -10,7 +10,7 @@ const TinyHead: React.FC<Props> = ({ config }) => {
   return (
     <>
       {cssBundle ? <link rel="stylesheet" href={cssBundle} /> : null}
-      <link rel="preload" href={jsBundle} as="fetch" crossOrigin="anonymous" />
+      <link rel="preload" href={jsBundle} as="script" crossOrigin="anonymous" />
       <script dangerouslySetInnerHTML={{ __html: moduleConfigScript }} />
     </>
   );


### PR DESCRIPTION
Update to preload `script` instead of `fetch`. This will be required when using tiny-client `0.0.7` (see: https://github.com/tiny-frontend/tiny-client/pull/8)