### PR TITLE
fix: add root element to withHydrationSuppress

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tiny-frontend/tiny-client-react",
-  "version": "0.0.3",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tiny-frontend/tiny-client-react",
-      "version": "0.0.2",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "@cazoo/eslint-plugin-eslint": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiny-frontend/tiny-client-react",
-  "version": "0.0.3",
+  "version": "1.0.0",
   "license": "MIT",
   "scripts": {
     "dev": "vite",

--- a/src/withHydrationSuppress.tsx
+++ b/src/withHydrationSuppress.tsx
@@ -6,26 +6,28 @@ import { useBundle } from "./useBundle";
 // The withHydrationSuppress HOC will prevent React from hydrating any SSR HTML until a client side
 // component, received from a bundle, is made available.
 
-// This achieved by falling back to an empty element with suppressHydrationWarning enabled.
+// This is achieved by falling back to an empty element with suppressHydrationWarning enabled.
 // You can find the documentation for suppressHydrationWarning at https://reactjs.org/docs/dom-elements.html#suppresshydrationwarning.
+// RootElement has to be the same element type as the root of the loaded component!
 
 // We got the idea from https://github.com/valcol/react-hydration-on-demand, but as the library provided
 // many other capabilities that we don't require and also a big package dependency, we ported just the
 // needed code.
 
 export const withHydrationSuppress = function <T>(
-  loader: BundleLoader<ComponentType<T>>
+  loader: BundleLoader<ComponentType<T>>,
+  RootElement: keyof JSX.IntrinsicElements
 ) {
   // eslint-disable-next-line react/display-name
   return ({ ...props }: T) => {
     const Component = useBundle<ComponentType<T>>({
-      loader
+      loader,
     });
 
     return Component ? (
       <Component {...props} />
     ) : (
-      <div
+      <RootElement
         dangerouslySetInnerHTML={{ __html: "" }}
         suppressHydrationWarning={true}
       />


### PR DESCRIPTION
BREAKING CHANGE: withHydrationSuppress now requires a 2nd parameter - RootElement, which has to be the same type of element as the root of the loaded component