### PR TITLE
Add SSR content replacement by element id

### DIFF
--- a/src/withHydrationSuppress.test.tsx
+++ b/src/withHydrationSuppress.test.tsx
@@ -3,21 +3,48 @@ import React from "react";
 
 import { withHydrationSuppress } from "./withHydrationSuppress";
 
+const id = "my-tiny-id";
+const ssrContent = "Hello from SSR!";
+const bundleContent = "Hello from bundle!";
+
+const renderElement = (textContent: string) => (
+  <div id={id}>
+    <span>{textContent}</span>
+  </div>
+);
+
 const renderWithHydrationSuppress = (loader) => {
-  const Component = withHydrationSuppress(loader, "div");
+  const Component = withHydrationSuppress(loader, id);
   return render(<Component />);
 };
 
+const hybridRender = (shouldCleanSsr: boolean) => {
+  // simulate ssr render
+  const { unmount } = render(renderElement(ssrContent));
+
+  // simulate csr render
+  const promise = Promise.resolve(() => renderElement(bundleContent));
+  const loader = () => promise;
+  renderWithHydrationSuppress(loader);
+
+  // simulate ssr content cleanup after renderWithHydrationSuppress had run
+  shouldCleanSsr && unmount();
+};
+
 describe("[withHydrationSuppress]", () => {
-  describe("when the loader resolves", () => {
-    it("should render the result from the loader", async () => {
-      const promise = Promise.resolve(() => <span>Hello from bundle!</span>);
-      const loader = () => promise;
-
-      renderWithHydrationSuppress(loader);
-      const expected = await screen.findByText("Hello from bundle!");
-
-      expect(expected).toBeInTheDocument();
+  describe("loader", () => {
+    describe("is resolving", () => {
+      it("should render the previous ssr content by fetching the element by id", async () => {
+        hybridRender(false);
+        expect(await screen.findByText(ssrContent)).toBeInTheDocument();
+      });
+      describe("is resolved", () => {
+        it("should render the result from the loader", async () => {
+          hybridRender(true);
+          expect(await screen.findByText(ssrContent)).not.toBeInTheDocument();
+          expect(await screen.findByText(bundleContent)).toBeInTheDocument();
+        });
+      });
     });
   });
 });

--- a/src/withHydrationSuppress.tsx
+++ b/src/withHydrationSuppress.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import React, { ComponentType, HTMLAttributes } from "react";
 
 import { BundleLoader } from "./types";
 import { useBundle } from "./useBundle";
@@ -16,8 +16,13 @@ import { useBundle } from "./useBundle";
 
 export const withHydrationSuppress = function <T>(
   loader: BundleLoader<ComponentType<T>>,
-  RootElement: keyof JSX.IntrinsicElements
+  id?: HTMLAttributes<T>["id"]
 ) {
+  let element;
+  if (typeof window !== "undefined" && id) {
+    element = document?.getElementById(id)?.children[0].outerHTML;
+  }
+
   // eslint-disable-next-line react/display-name
   return ({ ...props }: T) => {
     const Component = useBundle<ComponentType<T>>({
@@ -27,8 +32,10 @@ export const withHydrationSuppress = function <T>(
     return Component ? (
       <Component {...props} />
     ) : (
-      <RootElement
-        dangerouslySetInnerHTML={{ __html: "" }}
+      <div
+        dangerouslySetInnerHTML={{
+          __html: element ?? "",
+        }}
         suppressHydrationWarning={true}
       />
     );


### PR DESCRIPTION
With this we can now provide an element id that will allow us to
save the previous rendered html and have our HOC render it until it
resolves its promise (which will return the component definition).